### PR TITLE
Breaking change-rename clone task workspace from artifacts to workspace

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -40,7 +40,7 @@ Note: Specific access token can be provided specifically by providing a value fo
 
 ## Workspaces
 
-* **artifacts**: The git repo will be cloned onto the volume backing this workspace
+* **workspace**: The git repo will be cloned onto the volume backing this workspace
 
 ## Outputs
 The output of this task is the repository cloned into the directory on the workspace `artifacts`.

--- a/git/sample-git-trigger/pipeline-sample-git-trigger.yaml
+++ b/git/sample-git-trigger/pipeline-sample-git-trigger.yaml
@@ -55,7 +55,7 @@ spec:
         - name: gitCredentialsJsonFile
           value: $(params.gitCredentialsJsonFile)
       workspaces:
-        - name: artifacts
+        - name: workspace
           workspace: pipeline-ws
     - name: pipeline-git-event-content-inspect
       runAfter: [pipeline-git-event-clone-task]

--- a/git/sample/pipeline-simple-clone.yaml
+++ b/git/sample/pipeline-simple-clone.yaml
@@ -15,7 +15,7 @@ spec:
       taskRef:
         name: clone-repo-task
       workspaces:
-        - name: artifacts
+        - name: workspace
           workspace: pipeline-ws
       params:
         - name: repository

--- a/git/task-clone-repo.yaml
+++ b/git/task-clone-repo.yaml
@@ -60,8 +60,9 @@ spec:
           Default to '' meaning no output of this information
         default: ''
   workspaces:
-    - name: artifacts
+    - name: workspace
       description: The git repo will be cloned onto the volume backing this workspace
+      mountPath: /artifacts
   stepTemplate:
     env:
       - name: API_KEY
@@ -185,7 +186,7 @@ spec:
           echo "Cloning $REPOSITORY"
           # Add the proper creds to the git repository
           GIT_URL=$(echo "$REPOSITORY" | sed -e "s/:\/\//:\/\/$GIT_AUTH_USER:$GIT_TOKEN@/g")
-          ARTIFACTS_PATH="$(workspaces.artifacts.path)"
+          ARTIFACTS_PATH="$(workspaces.workspace.path)"
           cd $ARTIFACTS_PATH
           if [ "$REVISION" ]; then
             # check if the branch exists (that may not be the case in case of a pipeline-run re-run)


### PR DESCRIPTION
Rename expected workspace in clone task from `artifacts` to `workspace` to be consistent with other tasks in the catalog until now