### PR TITLE
Set commit status and skip ci task

### DIFF
--- a/github/task-set-commit-status.yaml
+++ b/github/task-set-commit-status.yaml
@@ -48,7 +48,7 @@ spec:
         type: string
       - name: revision
         description: |
-          Commit SHA to set the status for.
+          Commit SHA to set the status for. If left empty, will attempt to read GIT_COMMIT from build-properties
         type: string
         default: ''
       - name: target-url
@@ -175,6 +175,7 @@ spec:
         if os.path.exists("$(workspaces.workspace.path)/$(inputs.params.build-properties)"):
             build_properties = open("$(workspaces.workspace.path)/$(inputs.params.build-properties)", "r")
             for x in build_properties:
+                print(x)
                 prop = x.split("=", 1)
                 os.environ[prop[0]] = prop[1].strip()
             build_properties.close()
@@ -183,8 +184,12 @@ spec:
         if "$(inputs.params.state-var)" != "":
             state = os.environ["$(inputs.params.state-var)"]
 
-        status_url = "$(inputs.params.api-path-prefix)" + "/repos/$(inputs.params.repository)/" + \
-            "statuses/$(inputs.params.revision)"
+        revision = "$(inputs.params.revision)"
+        if revision == "":
+            revision = os.environ["GIT_COMMIT"]
+            print(revision)
+
+        status_url = "$(inputs.params.api-path-prefix)" + "/repos/$(inputs.params.repository)/statuses/" + revision
         data = {
             "state": state,
             "target_url": "$(inputs.params.target-url)",
@@ -208,7 +213,7 @@ spec:
             print(resp.read())
         else:
           print("GitHub status '$(inputs.params.state)' has been set on "
-                "$(inputs.params.repository)#$(inputs.params.revision) ")
+                "$(inputs.params.repository)#" + revision)
       volumeMounts:
         - mountPath: /steps
           name: steps-volume

--- a/github/task-set-commit-status.yaml
+++ b/github/task-set-commit-status.yaml
@@ -1,0 +1,223 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: github-set-status
+  description: This task will set CI status on the commit
+spec:
+  workspaces:
+    - name: workspace
+      description: The build-properties will be found and written here
+      mountPath: /artifacts
+  inputs:
+    params:
+      - name: ibmcloud-api
+        description: the ibmcloud api
+        default: https://cloud.ibm.com
+      - name: continuous-delivery-context-secret
+        description: name of the configmap containing the continuous delivery pipeline context secrets
+        default: cd-secret
+      - name: ibmcloud-apikey-secret-key
+        description: field in the secret that contains the api key used to login to ibmcloud
+        default: 'API_KEY'
+      - name: git-access-token
+        description: |
+          (optional) token to access the git repository. If this token is provided, there will not be an attempt
+          to use the git token obtained from the authorization flow when adding the git integration in the toolchain
+        default: ''
+      - name: resource-group
+        description: target resource group (name or id) for the ibmcloud login operation
+        default: ''
+      - name: github-host-url
+        description: |
+          The GitHub host, adjust this if you run a GitHub enteprise.
+        default: "api.github.com"
+        type: string
+      - name: api-path-prefix
+        description: |
+          The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+        default: ''
+        type: string
+      - name: repository-url
+        description: |
+          The GitHub repository's clone_url
+        type: string
+      - name: repository
+        description: |
+          The GitHub repository full name, i.e: org/repo
+        type: string
+      - name: revision
+        description: |
+          Commit SHA to set the status for.
+        type: string
+        default: ''
+      - name: target-url
+        description: |
+          The target URL to associate with this status. This URL will be linked
+          from the GitHub UI to allow users to easily see the source of the
+          status.
+        type: string
+      - name: description
+        description: |
+          A short description of the status.
+        type: string
+      - name: context
+        description: |
+          The GitHub context, A string label to differentiate this status from
+          the status of other systems. ie: "continuous-integration/tekton"
+        default: "continuous-integration/tekton"
+        type: string
+      - name: state
+        description: |
+          The state of the status. Can be one of the following `error`,
+          `failure`, `pending`, or `success`.
+      - name: state-var
+        description: |
+          Customized variable stored in build-properties to use as state.
+        type: string
+        default: ''
+      - name: build-properties
+        description: file containing properties out of clone task (can be a filepath name relative to the workspace)
+        default: build.properties
+  stepTemplate:
+    env:
+      - name: API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: $(inputs.params.continuous-delivery-context-secret)
+            key: $(inputs.params.ibmcloud-apikey-secret-key)
+            optional: true
+  steps:
+    - name: fetch-git-token
+      image: ibmcom/pipeline-base-image
+      env:
+        - name: REPOSITORY
+          value: $(inputs.params.repository-url)
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          set -e -o pipefail
+          TOOLCHAIN_ID=$(jq -r '.toolchain_guid' /cd-config/toolchain.json)
+          TOOLCHAIN_REGION=$(jq -r '.region_id' /cd-config/toolchain.json | awk -F: '{print $3}')
+          ##########################################################################
+          # Setting HOME explicitly to have ibmcloud plugins available
+          # doing the export rather than env definition is a workaround
+          # until https://github.com/tektoncd/pipeline/issues/1836 is fixed
+          export HOME="/root"
+          ##########################################################################
+          if [[ "$REPOSITORY" != *.git ]]; then
+            echo "Adding .git suffix to Repository URL"
+            REPOSITORY="${REPOSITORY}.git"
+          fi
+          GIT_SERVICE_INSTANCE_ID=$(jq -r --arg git_repo "$REPOSITORY" '.services[] | select (.parameters.repo_url==$git_repo) | .instance_id' /cd-config/toolchain.json)
+          if [ -z "$GIT_SERVICE_INSTANCE_ID" ]; then
+            echo "No Git integration (repository url: $REPOSITORY) found in the toolchain"
+            exit 1
+          fi
+          GIT_SERVICE_TYPE=$(jq -r --arg git_repo "$REPOSITORY" '.services[] | select (.parameters.repo_url==$git_repo) | .service_id' /cd-config/toolchain.json)
+          if [ "$GIT_SERVICE_TYPE" == "github" ]; then
+            GIT_AUTH_USER="x-oauth-basic"
+          elif [ "$GIT_SERVICE_TYPE" == "githubpublic" ]; then
+            GIT_AUTH_USER="x-oauth-basic"
+          elif [ "$GIT_SERVICE_TYPE" == "hostedgit" ]; then
+            GIT_AUTH_USER="oauth2"
+          elif [ "$GIT_SERVICE_TYPE" == "gitlab" ]; then
+            GIT_AUTH_USER="oauth2"
+          elif [ "$GIT_SERVICE_TYPE" == "bitbucketgit" ]; then
+            GIT_AUTH_USER="x-token-auth"
+          else
+            GIT_AUTH_USER="x-token-auth"
+          fi;
+          GIT_TOKEN="$(inputs.params.git-access-token)"
+          if [ -z "$GIT_TOKEN" ]; then
+            echo "Fetching token for $REPOSITORY"
+            ibmcloud config --check-version false
+            ibmcloud login -a $(inputs.params.ibmcloud-api) -r $TOOLCHAIN_REGION --apikey $API_KEY
+            if [ "$(inputs.params.resource-group)" ]; then
+              ibmcloud target -g $(inputs.params.resource-group)
+            fi
+            TOKEN=$(ibmcloud iam oauth-tokens --output JSON | jq -r '.iam_token')
+            GIT_TOKEN_URL=$(jq -r --arg git_repo "$REPOSITORY" '.services[] | select (.parameters.repo_url==$git_repo) | .parameters.token_url' /cd-config/toolchain.json)
+            echo "Doing cURL to ${GIT_TOKEN_URL}?toolchain_id=${TOOLCHAIN_ID}&service_instance_id=${GIT_SERVICE_INSTANCE_ID}&repo_url=${REPOSITORY}"
+            curl -s -o /steps/github_token_result.json -X GET -H "Accept: application/json" -H "Authorization: $TOKEN" "${GIT_TOKEN_URL}?toolchain_id=${TOOLCHAIN_ID}&service_instance_id=${GIT_SERVICE_INSTANCE_ID}&repo_url=${REPOSITORY}"
+            if jq -e '.access_token' /steps/github_token_result.json > /dev/null 2>&1; then
+              GIT_TOKEN=$(jq -r '.access_token' /steps/github_token_result.json)
+              echo "Access token found for the Git integration (repository url: $REPOSITORY)"
+            else
+              echo "No access token found for the Git integration (repository url: $REPOSITORY)"
+              cat /steps/github_token_result.json
+              exit 1
+            fi
+          else
+            echo "Using git Access Token provided"
+          fi
+
+          echo "GIT_TOKEN=$GIT_TOKEN" >> /steps/next-step-env.properties
+      volumeMounts:
+        - mountPath: /cd-config
+          name: cd-config-volume
+        - mountPath: /steps
+          name: steps-volume
+    - name: set-status
+      image: registry.access.redhat.com/ubi8/ubi:latest
+      script: |
+        #!/usr/libexec/platform-python
+        import json
+        import os
+        import http.client
+
+        previous_step = open("/steps/next-step-env.properties", "r")
+        for x in previous_step:
+            prop = x.split("=", 1)
+            os.environ[prop[0]] = prop[1].strip()
+        previous_step.close()
+
+        if os.path.exists("$(workspaces.workspace.path)/$(inputs.params.build-properties)"):
+            build_properties = open("$(workspaces.workspace.path)/$(inputs.params.build-properties)", "r")
+            for x in build_properties:
+                prop = x.split("=", 1)
+                os.environ[prop[0]] = prop[1].strip()
+            build_properties.close()
+
+        state = "$(inputs.params.state)"
+        if "$(inputs.params.state-var)" != "":
+            state = os.environ["$(inputs.params.state-var)"]
+
+        status_url = "$(inputs.params.api-path-prefix)" + "/repos/$(inputs.params.repository)/" + \
+            "statuses/$(inputs.params.revision)"
+        data = {
+            "state": state,
+            "target_url": "$(inputs.params.target-url)",
+            "description": "$(inputs.params.description)",
+            "context": "$(inputs.params.context)"
+        }
+        print("Sending this data to GitHub: ")
+        print(data)
+        conn = http.client.HTTPSConnection("$(inputs.params.github-host-url)")
+        r = conn.request(
+            "POST",
+            status_url,
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": "Bearer " + os.environ["GIT_TOKEN"],
+            })
+        resp = conn.getresponse()
+        if not str(resp.status).startswith("2"):
+            print("Error: %d" % (resp.status))
+            print(resp.read())
+        else:
+          print("GitHub status '$(inputs.params.state)' has been set on "
+                "$(inputs.params.repository)#$(inputs.params.revision) ")
+      volumeMounts:
+        - mountPath: /steps
+          name: steps-volume
+  volumes:
+    - name: steps-volume
+      emptyDir: {}
+    - name: cd-config-volume
+      configMap:
+        name: toolchain
+        items:
+          - key: toolchain.json
+            path: toolchain.json

--- a/github/task-skip-ci.yaml
+++ b/github/task-skip-ci.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: skip-ci
+spec:
+  workspaces:
+    - name: workspace
+      description: The workspace containing the cloned repo
+      mountPath: /artifacts
+  inputs:
+    params:
+      - name: repository-dir
+        description: The directory the repository was cloned into, relative to workspace path.
+      - name: build-properties
+        description: |
+          (optional) If this file is provided, build does not fail.
+          Instead, skip_ci=true gets wrtten in the file.
+        default: ''
+  steps:
+    - name: check-commit-message
+      image: ibmcom/pipeline-base-image
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          set -e
+          cd $(workspaces.workspace.path)/$(inputs.params.repository-dir)
+
+          commit_message=$(git show -s --format=%s)
+          echo $commit_message
+
+          if [[ "${commit_message}" = "[skip ci]"* ]]; then
+            if [[ "" = "$(inputs.params.build-properties)" ]]; then
+              exit 1
+            else
+              echo skip_ci=true >> $(workspaces.workspace.path)/$(inputs.params.build-properties)
+            fi
+          fi


### PR DESCRIPTION
Set commit status:
- Modified from https://github.com/tektoncd/catalog/blob/master/github/set_status.yaml
- TODO: We should have the ability to generate the 'target_url', I just don't quite have the capacity to figure it out, and it's a good to have, not necessity for my use case.

Skip ci:
- looks for [skip ci] prefix to set a skip_ci=true value in build-properties file (if provided). Fails the build if no build-properties is provided.