### PR TITLE
Fix inconsistent yaml indentation

### DIFF
--- a/container-registry/sample-cr-build/pipeline-cr-build.yaml
+++ b/container-registry/sample-cr-build/pipeline-cr-build.yaml
@@ -15,8 +15,8 @@ spec:
     - name: pipeline-debug
       default: "0"
   resources:
-  - name: app-image
-    type: image
+    - name: app-image
+      type: image
   tasks:
     - name: pipeline-1-clone-task
       taskRef:

--- a/container-registry/sample-docker-dind-cluster/pipeline-docker-dind-cluster.yaml
+++ b/container-registry/sample-docker-dind-cluster/pipeline-docker-dind-cluster.yaml
@@ -11,10 +11,10 @@ spec:
     - name: branch
       description: the branch for the git repo
   resources:
-  - name: app-image
-    type: image
-  - name: build-cluster
-    type: cluster
+    - name: app-image
+      type: image
+    - name: build-cluster
+      type: cluster
   tasks:
     - name: clone-repository
       taskRef:

--- a/container-registry/sample-docker-dind-sidecar/pipeline-docker-in-docker.yaml
+++ b/container-registry/sample-docker-dind-sidecar/pipeline-docker-in-docker.yaml
@@ -11,8 +11,8 @@ spec:
     - name: branch
       description: the branch for the git repo
   resources:
-  - name: app-image
-    type: image
+    - name: app-image
+      type: image
   tasks:
     - name: clone-repository
       taskRef:

--- a/container-registry/sample/pipeline-container-registry.yaml
+++ b/container-registry/sample/pipeline-container-registry.yaml
@@ -15,8 +15,8 @@ spec:
     - name: pipeline-debug
       default: "0"
   resources:
-  - name: app-image
-    type: image
+    - name: app-image
+      type: image
   tasks:
     - name: pipeline-1-clone-task
       taskRef:

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -322,11 +322,11 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json
     - name: check-registry-script
       configMap: 
         name: check-registry-script
         items: 
-        - key: check_registry.sh
-          path: check_registry.sh          
+          - key: check_registry.sh
+            path: check_registry.sh          

--- a/container-registry/task-cr-build.yaml
+++ b/container-registry/task-cr-build.yaml
@@ -235,11 +235,11 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json
     - name: check-registry-script
       configMap: 
         name: check-registry-script
         items: 
-        - key: check_registry.sh
-          path: check_registry.sh
+          - key: check_registry.sh
+            path: check_registry.sh

--- a/container-registry/task-docker-dind-cluster.yaml
+++ b/container-registry/task-docker-dind-cluster.yaml
@@ -372,11 +372,11 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json
     - name: check-registry-script
       configMap: 
         name: check-registry-script
         items: 
-        - key: check_registry.sh
-          path: check_registry.sh
+          - key: check_registry.sh
+            path: check_registry.sh

--- a/container-registry/task-docker-in-docker.yaml
+++ b/container-registry/task-docker-in-docker.yaml
@@ -252,11 +252,11 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json
     - name: check-registry-script
       configMap: 
         name: check-registry-script
         items: 
-        - key: check_registry.sh
-          path: check_registry.sh
+          - key: check_registry.sh
+            path: check_registry.sh

--- a/container-registry/task-vulnerability-advisor.yaml
+++ b/container-registry/task-vulnerability-advisor.yaml
@@ -210,8 +210,8 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json
     - name: task-volume
       persistentVolumeClaim:
         claimName: $(inputs.params.task-pvc)

--- a/git/task-clone-repo.yaml
+++ b/git/task-clone-repo.yaml
@@ -331,5 +331,5 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json

--- a/kubernetes-service/sample/pipeline-kubernetes-service.yaml
+++ b/kubernetes-service/sample/pipeline-kubernetes-service.yaml
@@ -8,8 +8,8 @@ spec:
       description: the pipeline pvc name
     - name: resourceGroup
   resources:
-  - name: target-cluster
-    type: cluster
+    - name: target-cluster
+      type: cluster
   tasks:
     - name: pipeline-0-setup-task
       taskRef:

--- a/kubernetes-service/task-fetch-iks-cluster-config.yaml
+++ b/kubernetes-service/task-fetch-iks-cluster-config.yaml
@@ -144,5 +144,5 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json

--- a/kubernetes-service/task-kubernetes-contextual-execution.yaml
+++ b/kubernetes-service/task-kubernetes-contextual-execution.yaml
@@ -92,5 +92,5 @@ spec:
       configMap:
         name: toolchain
         items:
-        - key: toolchain.json
-          path: toolchain.json
+          - key: toolchain.json
+            path: toolchain.json


### PR DESCRIPTION
both

```yaml
key:
- some
- values
```

and

```yaml
key:
  - some
  - values
```

are valid, and they parse into the same document (the syntax is not ambiguous, so you can omit the indentation), but right now the style is not consistent. This PR tries to resolve this by adjusting the indentation to use the second style in every definition.