### PR TITLE
Remove git token from task results as it is unsecured

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -47,7 +47,6 @@
 * **git-branch**: The active branch for the repository
 * **git-commit**: The current commit id that was cloned
 * **git-user**: The auth user that cloned the repository
-* **git-token**: The auth token that cloned the repository
 
 ### Outcome
 The output of this task is the repository cloned into the directory on the workspace `workspace`.

--- a/git/sample-git-trigger/pipeline-sample-git-trigger.yaml
+++ b/git/sample-git-trigger/pipeline-sample-git-trigger.yaml
@@ -80,5 +80,3 @@ spec:
           value: $(tasks.pipeline-git-event-clone-task.results.git-commit)
         - name: git-user
           value: $(tasks.pipeline-git-event-clone-task.results.git-user)
-        - name: git-token
-          value: $(tasks.pipeline-git-event-clone-task.results.git-token)

--- a/git/sample-git-trigger/task-inspect-git-content.yaml
+++ b/git/sample-git-trigger/task-inspect-git-content.yaml
@@ -19,8 +19,6 @@ spec:
       description: The current commit id that was cloned
     - name: git-user
       description: The auth user that cloned the repository
-    - name: git-token
-      description: The auth token that cloned the repository
   workspaces:
     - name: workspace
       mountPath: /artifacts
@@ -72,4 +70,4 @@ spec:
           echo "params.git-branch: $(params.git-branch)"
           echo "params.git-commit: $(params.git-commit)"
           echo "params.git-user: $(params.git-user)"
-          echo "params.git-token: ***"
+

--- a/git/task-clone-repo.yaml
+++ b/git/task-clone-repo.yaml
@@ -71,8 +71,6 @@ spec:
       description: The current commit id that was cloned
     - name: git-user
       description: The auth user that cloned the repository
-    - name: git-token
-      description: The auth token that cloned the repository
   workspaces:
     - name: output
       description: The git repo will be cloned onto the volume backing this workspace
@@ -350,7 +348,6 @@ spec:
           echo -n "${BRANCH}" > $(results.git-branch.path)
           echo -n "${GIT_COMMIT}" > $(results.git-commit.path)
           echo -n "${GIT_AUTH_USER}" > $(results.git-user.path)
-          echo -n "${GIT_TOKEN}" > $(results.git-token.path)
       volumeMounts:
         - mountPath: /steps
           name: steps-volume


### PR DESCRIPTION
As passed using termination log mechanism and shown in the log status of CD Tekton Dashboard
Use git-credentials-json-file mechanism is this info is required in subsequent task in a pipeline