### PR TITLE
Upgrade pipeline-base-image for cr-build task to benefit from 'ibmcloud cr image-digests' command

### DIFF
--- a/container-registry/task-cr-build.yaml
+++ b/container-registry/task-cr-build.yaml
@@ -226,13 +226,6 @@ spec:
             ibmcloud cr image-tag $(head --lines=1 /steps/tags.lst) $tag
           done
 
-          # Workaround to reference the latest ibmcloud cr plugin
-          if ibmcloud cr image-digests; then
-            echo "ibmcloud cr plugin has an appropriate version containing image-digests command"
-          else
-            ibmcloud plugin update container-registry --force
-          fi
-
           IMAGE_TAG=$(head --lines=1 /steps/tags.lst |  awk -F: '{print $2}')
           echo "**"
           echo "** ibmcloud cr image-digests --restrict ${REGISTRY_NAMESPACE}/${IMAGE_NAME}"

--- a/container-registry/task-cr-build.yaml
+++ b/container-registry/task-cr-build.yaml
@@ -75,7 +75,7 @@ spec:
         optional: true
   steps:
     - name: check-registry-and-build-image
-      image: ibmcom/pipeline-base-image:2.6
+      image: ibmcom/pipeline-base-image:2.7
       workingDir: /artifacts
       env:
         - name: API_KEY


### PR DESCRIPTION
Upgrade pipeline-base-image for cr-build task to benefit from 'ibmcloud cr image-digests' command