### PR TITLE
Refactor: set default name for CD pipeline provided secrets

### DIFF
--- a/container-registry/task-check-va-scan.yaml
+++ b/container-registry/task-check-va-scan.yaml
@@ -10,7 +10,7 @@ spec:
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
       description: Name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      default: "secure-properties"
     - name: container-registry-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud container registry
       default: "API_KEY"

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -10,7 +10,7 @@ spec:
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
       description: Name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      default: "secure-properties"
     - name: container-registry-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud container registry
       default: "API_KEY"

--- a/container-registry/task-cr-build.yaml
+++ b/container-registry/task-cr-build.yaml
@@ -10,7 +10,7 @@ spec:
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
       description: Name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      default: "secure-properties"
     - name: container-registry-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud container registry
       default: "API_KEY"

--- a/container-registry/task-execute-in-dind-cluster.yaml
+++ b/container-registry/task-execute-in-dind-cluster.yaml
@@ -9,8 +9,8 @@ spec:
       description: the ibmcloud api
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
-      description: name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      description: Name of the secret containing the continuous delivery pipeline context secrets
+      default: "secure-properties"
     - name: container-registry-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud container registry
       default: "API_KEY"

--- a/container-registry/task-execute-in-dind.yaml
+++ b/container-registry/task-execute-in-dind.yaml
@@ -9,8 +9,8 @@ spec:
       description: the ibmcloud api
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
-      description: name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      description: Name of the secret containing the continuous delivery pipeline context secrets
+      default: "secure-properties"
     - name: container-registry-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud container registry
       default: "API_KEY"

--- a/git/task-clone-repo.yaml
+++ b/git/task-clone-repo.yaml
@@ -9,8 +9,8 @@ spec:
       description: the ibmcloud api
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
-      description: name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      description: Name of the secret containing the continuous delivery pipeline context secrets
+      default: "secure-properties"
     - name: ibmcloud-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud
       default: "API_KEY"

--- a/git/task-set-commit-status.yaml
+++ b/git/task-set-commit-status.yaml
@@ -11,7 +11,7 @@ spec:
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
       description: Name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      default: "secure-properties"
     - name: ibmcloud-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud
       default: "API_KEY"

--- a/kubernetes-service/task-fetch-config.yaml
+++ b/kubernetes-service/task-fetch-config.yaml
@@ -9,8 +9,8 @@ spec:
       description: the ibmcloud api
       default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
-      description: name of the secret containing the continuous delivery pipeline context secrets
-      default: cd-secret
+      description: Name of the secret containing the continuous delivery pipeline context secrets
+      default: "secure-properties"
     - name: kubernetes-service-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud kubernetes service
       default: "API_KEY"


### PR DESCRIPTION
I've noticed in some tasks the old name is used for Continuous Delivery pipeline context secrets.
This PR aims to fix this, and use the "official" name in tasks `secure-properties`.