### PR TITLE
Refactor: set default name for CD pipeline provided secrets

### DIFF
--- a/container-registry/README.md
+++ b/container-registry/README.md
@@ -20,7 +20,7 @@
 
   The task expects the following kubernetes resources to be defined:
 
-* **Secret cd-secret**
+* **Secret secure-properties**
 
   Secret containing:
   * **API_KEY**: An [IBM Cloud Api Key](https://cloud.ibm.com/iam/apikeys) used to access to the IBM Cloud Container registry service.
@@ -53,7 +53,7 @@
 
   The task expects the following kubernetes resources to be defined:
 
-* **Secret cd-secret**
+* **Secret secure-properties**
 
   Secret containing:
   * **API_KEY**: An [IBM Cloud Api Key](https://cloud.ibm.com/iam/apikeys) used to access to the IBM Cloud Container registry service.
@@ -90,7 +90,7 @@ and is available only during the task's lifespan.
 
   The task expects the following kubernetes resources to be defined:
 
-* **Secret cd-secret**
+* **Secret secure-properties**
 
   Secret containing:
   * **API_KEY**: An [IBM Cloud Api Key](https://cloud.ibm.com/iam/apikeys) used to access to the IBM Cloud Container registry service.
@@ -129,7 +129,7 @@ This task runs `docker` commands (build, inspect...) that communicate with a doc
 
   The task expects the following kubernetes resources to be defined:
 
-* **Secret cd-secret**
+* **Secret secure-properties**
 
   Secret containing:
   * **API_KEY**: An [IBM Cloud Api Key](https://cloud.ibm.com/iam/apikeys) used to access to the IBM Cloud Container registry service.
@@ -174,7 +174,7 @@ docker push ${IMAGE_URL}:${IMAGE_TAG}
 
   The task expects the following kubernetes resources to be defined:
 
-* **Secret cd-secret**
+* **Secret secure-properties**
 
   Secret containing:
   * **API_KEY**: An [IBM Cloud Api Key](https://cloud.ibm.com/iam/apikeys) used to access to the IBM Cloud Container registry service.

--- a/container-registry/sample-cr-build/listener-cr-build-no-resources.yaml
+++ b/container-registry/sample-cr-build/listener-cr-build-no-resources.yaml
@@ -21,7 +21,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/sample-cr-build/listener-cr-build.yaml
+++ b/container-registry/sample-cr-build/listener-cr-build.yaml
@@ -21,7 +21,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster-no-resources.yaml
+++ b/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster-no-resources.yaml
@@ -19,7 +19,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster.yaml
+++ b/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster.yaml
@@ -19,7 +19,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/sample-docker-dind-sidecar/listener-dind-sidecar-no-resources.yaml
+++ b/container-registry/sample-docker-dind-sidecar/listener-dind-sidecar-no-resources.yaml
@@ -17,7 +17,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/sample-docker-dind-sidecar/listener-docker-in-docker.yaml
+++ b/container-registry/sample-docker-dind-sidecar/listener-docker-in-docker.yaml
@@ -17,7 +17,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/sample/listener-buildkit-no-resources.yaml
+++ b/container-registry/sample/listener-buildkit-no-resources.yaml
@@ -21,7 +21,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/sample/listener-container-registry.yaml
+++ b/container-registry/sample/listener-container-registry.yaml
@@ -21,7 +21,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -12,7 +12,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the configmap containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: container-registry-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud container registry
         default: 'API_KEY'

--- a/container-registry/task-cr-build.yaml
+++ b/container-registry/task-cr-build.yaml
@@ -12,7 +12,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the configmap containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: container-registry-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud container registry
         default: 'API_KEY'

--- a/container-registry/task-docker-dind-cluster.yaml
+++ b/container-registry/task-docker-dind-cluster.yaml
@@ -12,7 +12,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the secret containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: container-registry-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud container registry
         default: 'API_KEY'

--- a/container-registry/task-docker-in-docker.yaml
+++ b/container-registry/task-docker-in-docker.yaml
@@ -12,7 +12,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the secret containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: container-registry-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud container registry
         default: 'API_KEY'

--- a/container-registry/task-vulnerability-advisor.yaml
+++ b/container-registry/task-vulnerability-advisor.yaml
@@ -12,7 +12,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the configmap containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: container-registry-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud container registry
         default: 'API_KEY'

--- a/git/README.md
+++ b/git/README.md
@@ -15,7 +15,7 @@
 
   The task expects the following kubernetes resource to be defined:
 
-* **Secret cd-secret (optional)**
+* **Secret secure-properties (optional)**
 
   Secret containing:
   * **API_KEY**: An IBM Cloud Api Key allowing access to the toolchain (and `Git Repos and Issue Tracking` service if used)
@@ -27,7 +27,7 @@
 #### Parameters
 
 * **task-pvc**: the output pvc - this is where the cloned repository will be stored
-* **gitAccessToken**: (optional) token to access the git repository. Either `cd-secret` or gitAccessToken has to be provided.
+* **gitAccessToken**: (optional) token to access the git repository. Either `secure-properties` or gitAccessToken has to be provided.
 * **repository**: the git repository url that the toolchain is integrating
 * **branch**: the git branch (default value to `master`). This param can also be given as a full _git ref_ like `refs/heads/master` (as described by [Git References](https://git-scm.com/book/en/v2/Git-Internals-Git-References))
 * **revision**: (optional) the git revision/commit to update the git HEAD to (default to empty meaning only use the branch information)
@@ -37,7 +37,7 @@
 * **directoryName**: (optional) name of the new directory to clone into (default to `.` in order to clone at the root of the volume mounted for the pipeline run). Note: It will be to the "humanish" part of the repository if this param is set to blank
 * **propertiesFile**: (optional) name of the properties file that will be created as an additional outcome of this task in the task-pvc. This file will contains the git related information (`GIT_URL`, `GIT_BRANCH` and `GIT_COMMIT`)
 * **resourceGroup**: (optional) target resource group (name or id) for the ibmcloud login operation
-* **continuous-delivery-context-secret**: (optional) name of the configmap containing the continuous delivery pipeline context secret (default to `cd-secret`)
+* **continuous-delivery-context-secret**: (optional) name of the configmap containing the continuous delivery pipeline context secret (default to `secure-properties`)
 * **gitCredentialsJsonFile**: (optional) name of JSON file to store git credentials found out of the clone task (it can be a file path relative to task-pvc volume). Default to '' meaning no output of this information.
 
 
@@ -52,7 +52,7 @@ The output of this task is the repository cloned into the directory on the pvc.
 
   The task expects the following kubernetes resource to be defined:
 
-* **Secret cd-secret (optional)**
+* **Secret secure-properties (optional)**
 
   Secret containing:
   * **API_KEY**: An IBM Cloud Api Key allowing access to the toolchain (and `Git Repos and Issue Tracking` service if used)
@@ -65,9 +65,9 @@ The output of this task is the repository cloned into the directory on the pvc.
 
 * **task-pvc**: the input pvc - this is where the properties file (like `build.properties` defined in `propertiesFile` parameter) would be stored
 * **resourceGroup**: (optional) target resource group (name or id) for the ibmcloud login operation
-* **continuous-delivery-context-secret**: (optional) name of the configmap containing the continuous delivery pipeline context secret (default to `cd-secret`)
+* **continuous-delivery-context-secret**: (optional) name of the configmap containing the continuous delivery pipeline context secret (default to `secure-properties`)
 * **ibmcloud-apikey-secret-key**: (optional) field in the secret that contains the api key used to login to ibmcloud (default to `API_KEY`)
-* **gitAccessToken**: (optional) token to access the git repository. Either `cd-secret` or gitAccessToken has to be provided.
+* **gitAccessToken**: (optional) token to access the git repository. Either `secure-properties` or gitAccessToken has to be provided.
 * **repository**: the git repository url that the toolchain is integrating
 * **revision**: the git revision/commit to update the status
 * **description**: A short description of the status.

--- a/git/sample-git-trigger/listener-sample-git-trigger.yaml
+++ b/git/sample-git-trigger/listener-sample-git-trigger.yaml
@@ -33,7 +33,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/git/sample-set-commit-status/listener-commit-status.yaml
+++ b/git/sample-set-commit-status/listener-commit-status.yaml
@@ -23,7 +23,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/git/sample-skip-ci/listener-skip-ci.yaml
+++ b/git/sample-skip-ci/listener-skip-ci.yaml
@@ -17,7 +17,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/git/sample/listener-simple-clone.yaml
+++ b/git/sample/listener-simple-clone.yaml
@@ -15,7 +15,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/git/task-clone-repo.yaml
+++ b/git/task-clone-repo.yaml
@@ -12,7 +12,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the secret containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: ibmcloud-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud
         default: 'API_KEY'

--- a/git/task-set-commit-status.yaml
+++ b/git/task-set-commit-status.yaml
@@ -14,7 +14,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the configmap containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: ibmcloud-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud
         default: 'API_KEY'

--- a/kubernetes-service/README.md
+++ b/kubernetes-service/README.md
@@ -17,7 +17,7 @@
 
   The task expects the following kubernetes resources to be defined:
 
-* **Secret cd-secret**
+* **Secret secure-properties**
 
   Secret containing:
   * **API_KEY**: An IBM Cloud Api Key use to access to the IBM Cloud Container registry service (https://cloud.ibm.com/iam/apikeys)
@@ -50,7 +50,7 @@
 
   The task expects the following kubernetes resources to be defined:
 
-* **Secret cd-secret**
+* **Secret secure-properties**
 
   Secret containing:
   * **API_KEY**: An IBM Cloud Api Key use to access to the IBM Cloud Container registry service (https://cloud.ibm.com/iam/apikeys)

--- a/kubernetes-service/sample/listener-kubernetes-service-no-resources.yaml
+++ b/kubernetes-service/sample/listener-kubernetes-service-no-resources.yaml
@@ -15,7 +15,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/kubernetes-service/sample/listener-kubernetes-service.yaml
+++ b/kubernetes-service/sample/listener-kubernetes-service.yaml
@@ -15,7 +15,7 @@ spec:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: cd-secret
+        name: secure-properties
       type: Opaque
       stringData:
         API_KEY: $(params.apikey)

--- a/kubernetes-service/task-fetch-iks-cluster-config.yaml
+++ b/kubernetes-service/task-fetch-iks-cluster-config.yaml
@@ -12,7 +12,7 @@ spec:
         default: https://cloud.ibm.com
       - name: continuous-delivery-context-secret
         description: name of the configmap containing the continuous delivery pipeline context secrets
-        default: cd-secret
+        default: secure-properties
       - name: kubernetes-service-apikey-secret-key
         description: field in the secret that contains the api key used to login to ibmcloud kubernetes service
         default: 'API_KEY'        


### PR DESCRIPTION
Some tasks use the old name as a default for the Continuous Delivery pipeline context secrets.
This PR aims to fix this, and use the "official" name in tasks secure-properties.