### PR TITLE
param to create namespace and don't list images in the namespace

### DIFF
--- a/container-registry/configmap-check-registry.yaml
+++ b/container-registry/configmap-check-registry.yaml
@@ -58,6 +58,7 @@ data:
     # - IBMCLOUD_RESOURCE_GROUP (input)
     # - REGISTRY_REGION (input)
     # - REGISTRY_NAMESPACE (input)
+    # - REGISTRY_CREATE_NAMESPACE (input)
     ##########################################################################
 
     TOOLCHAIN_ID=$(jq -r '.toolchain_guid' /cd-config/toolchain.json)
@@ -78,11 +79,13 @@ data:
     echo "Checking registry namespace: ${REGISTRY_NAMESPACE}"
     NS=$( ibmcloud cr namespaces | grep ${REGISTRY_NAMESPACE} ||: )
     if [ -z "${NS}" ]; then
-        echo "Registry namespace ${REGISTRY_NAMESPACE} not found, creating it."
-        ibmcloud cr namespace-add ${REGISTRY_NAMESPACE}
-        echo "Registry namespace ${REGISTRY_NAMESPACE} created."
+        echo "Registry namespace ${REGISTRY_NAMESPACE} not found"
+        if [ "$REGISTRY_CREATE_NAMESPACE" = true ] ; then
+          ibmcloud cr namespace-add ${REGISTRY_NAMESPACE}
+          echo "Registry namespace ${REGISTRY_NAMESPACE} created."
+        else
+          echo "Skipping creation of registry namespace ${REGISTRY_NAMESPACE}."
+        fi
     else
         echo "Registry namespace ${REGISTRY_NAMESPACE} found."
     fi
-    echo -e "Existing images in registry"
-    ibmcloud cr images --restrict ${REGISTRY_NAMESPACE}

--- a/container-registry/configmap-check-registry.yaml
+++ b/container-registry/configmap-check-registry.yaml
@@ -80,7 +80,7 @@ data:
     NS=$( ibmcloud cr namespaces | grep ${REGISTRY_NAMESPACE} ||: )
     if [ -z "${NS}" ]; then
         echo "Registry namespace ${REGISTRY_NAMESPACE} not found"
-        if [ "$REGISTRY_CREATE_NAMESPACE" = true ] ; then
+        if [ "$REGISTRY_CREATE_NAMESPACE" == "true" ] ; then
           ibmcloud cr namespace-add ${REGISTRY_NAMESPACE}
           echo "Registry namespace ${REGISTRY_NAMESPACE} created."
         else

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -29,6 +29,9 @@ spec:
     - name: registry-namespace
       description: container registry namespace. required if no image-url or no image pipeline resources provided
       default: ""
+    - name: registry-create-namespace
+      description: create container registry namespace if it doesn't already exists
+      default: true
     - name: image-name
       description: image name. required if no image-url or no image pipeline resources provided
       default: ""
@@ -94,6 +97,8 @@ spec:
           value: $(params.ibmcloud-api)
         - name: IBMCLOUD_RESOURCE_GROUP
           value: $(params.resource-group)
+        - name: REGISTRY_CREATE_NAMESPACE
+          value: $(params.registry-create-namespace)
       command: ["/bin/bash", "-c"]
       args:
         - |

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -31,7 +31,7 @@ spec:
       default: ""
     - name: registry-create-namespace
       description: create container registry namespace if it doesn't already exists
-      default: true
+      default: "true"
     - name: image-name
       description: image name. required if no image-url or no image pipeline resources provided
       default: ""

--- a/container-registry/task-cr-build.yaml
+++ b/container-registry/task-cr-build.yaml
@@ -31,7 +31,7 @@ spec:
       default: ""
     - name: registry-create-namespace
       description: create container registry namespace if it doesn't already exists
-      default: true
+      default: "true"
     - name: image-name
       description: image name. required if no image-url or no image pipeline resources provided
       default: ""

--- a/container-registry/task-cr-build.yaml
+++ b/container-registry/task-cr-build.yaml
@@ -29,6 +29,9 @@ spec:
     - name: registry-namespace
       description: container registry namespace. required if no image-url or no image pipeline resources provided
       default: ""
+    - name: registry-create-namespace
+      description: create container registry namespace if it doesn't already exists
+      default: true
     - name: image-name
       description: image name. required if no image-url or no image pipeline resources provided
       default: ""
@@ -89,6 +92,8 @@ spec:
           value: $(params.resource-group)
         - name: PROPERTIES_FILE
           value: $(params.properties-file)
+        - name: REGISTRY_CREATE_NAMESPACE
+          value: $(params.registry-create-namespace)
         - name: PIPELINE_DEBUG
           value: $(params.pipeline-debug)
         # CD execution context injection

--- a/container-registry/task-execute-in-dind-cluster.yaml
+++ b/container-registry/task-execute-in-dind-cluster.yaml
@@ -34,7 +34,7 @@ spec:
     #
     - name: registry-create-namespace
       description: create container registry namespace if it doesn't already exists
-      default: true
+      default: "true"
     - name: image-url
       description: "url of the image to build - required if no image pipeline resource provided to this task"
       default: ""

--- a/container-registry/task-execute-in-dind-cluster.yaml
+++ b/container-registry/task-execute-in-dind-cluster.yaml
@@ -32,6 +32,9 @@ spec:
       description: (optional) the kubernetes cluster namespace where the docker engine is hosted/deployed
       default: "build"
     #
+    - name: registry-create-namespace
+      description: create container registry namespace if it doesn't already exists
+      default: true
     - name: image-url
       description: "url of the image to build - required if no image pipeline resource provided to this task"
       default: ""
@@ -106,6 +109,8 @@ spec:
           value: $(params.ibmcloud-api)
         - name: IBMCLOUD_RESOURCE_GROUP
           value: $(params.resource-group)
+        - name: REGISTRY_CREATE_NAMESPACE
+          value: $(params.registry-create-namespace)
       command: ["/bin/bash", "-c"]
       args:
         - |

--- a/container-registry/task-execute-in-dind.yaml
+++ b/container-registry/task-execute-in-dind.yaml
@@ -19,7 +19,7 @@ spec:
       default: ""
     - name: registry-create-namespace
       description: create container registry namespace if it doesn't already exists
-      default: true
+      default: "true"
     # Image related parameters
     - name: image-url
       description: "url of the image to build - required if no image pipeline resource provided to this task"

--- a/container-registry/task-execute-in-dind.yaml
+++ b/container-registry/task-execute-in-dind.yaml
@@ -17,6 +17,9 @@ spec:
     - name: resource-group
       description: target resource group (name or id) for the ibmcloud login operation
       default: ""
+    - name: registry-create-namespace
+      description: create container registry namespace if it doesn't already exists
+      default: true
     # Image related parameters
     - name: image-url
       description: "url of the image to build - required if no image pipeline resource provided to this task"
@@ -87,6 +90,8 @@ spec:
           value: $(params.ibmcloud-api)
         - name: IBMCLOUD_RESOURCE_GROUP
           value: $(params.resource-group)
+        - name: REGISTRY_CREATE_NAMESPACE
+          value: $(params.registry-create-namespace)
       command: ["/bin/bash", "-c"]
       args:
         - |


### PR DESCRIPTION
Two reasons for this code change request
1. We would like users not to create namespaces in our registry, so the code change is to provide a param to disable creating namespace by default.
2. Our registry is a centralized registry for many teams and services, listing all images in a namespace is a huge waste of time and resources. We have about ~15k images in one namespace, listing it using `ibmcloud cr images --restrict ${REGISTRY_NAMESPACE}` takes a few minutes and fills up the console logs. So I am proposing code change to remove it all together.