### PR TITLE
Add ibm cloud cr quota check

### DIFF
--- a/container-registry/configmap-check-registry.yaml
+++ b/container-registry/configmap-check-registry.yaml
@@ -75,6 +75,12 @@ data:
     ibmcloud cr region-set $REGISTRY_REGION
     ibmcloud cr info
 
+    # Check available quota on CR
+    if ibmcloud cr quota | grep 'Your account has exceeded its storage quota.'; then
+      echo "Your account has exceeded its storage quota. You can check your images at https://cloud.ibm.com/kubernetes/registry/main/images"
+      exit 1
+    fi
+
     # Create the namespace if needed to ensure the push will be can be successfull
     echo "Checking registry namespace: ${REGISTRY_NAMESPACE}"
     NS=$( ibmcloud cr namespaces | grep ${REGISTRY_NAMESPACE} ||: )


### PR DESCRIPTION
Run and parse the result of `ibmcloud cr quota` to stop the script if the quota limit would fail the image build.