### PR TITLE
ci: add tekton linter and fix linting errors.

### DIFF
--- a/.github/workflows/tekton.yaml
+++ b/.github/workflows/tekton.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install tekton-lint
-        run: npm install -g tekton-lint
+        run: sudo npm install -g tekton-lint
 
       - name: Lint Tekton
         run: tekton-lint '**/*.yaml'

--- a/.github/workflows/tekton.yaml
+++ b/.github/workflows/tekton.yaml
@@ -25,4 +25,4 @@ jobs:
         run: sudo npm install -g tekton-lint
 
       - name: Lint Tekton
-        run: tekton-lint '**/*.yaml'
+        run: tekton-lint --color --max-warnings 0 '**/*.yaml'

--- a/.github/workflows/tekton.yaml
+++ b/.github/workflows/tekton.yaml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Tekton Lint
+
+on:
+  push:
+    paths-ignore: [ .git ]
+  pull_request:
+    paths-ignore: [ .git ]
+    
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job
+  tekton-lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install tekton-lint
+        run: npm install -g tekton-lint
+
+      - name: Lint Tekton
+        run: tekton-lint '**/*.yaml'

--- a/container-registry/sample-cr-build/listener-cr-build-no-resources.yaml
+++ b/container-registry/sample-cr-build/listener-cr-build-no-resources.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: path-to-dockerfile

--- a/container-registry/sample-cr-build/listener-cr-build.yaml
+++ b/container-registry/sample-cr-build/listener-cr-build.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: path-to-dockerfile

--- a/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster-no-resources.yaml
+++ b/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster-no-resources.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: build-cluster

--- a/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster.yaml
+++ b/container-registry/sample-docker-dind-cluster/listener-docker-dind-cluster.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: build-cluster

--- a/container-registry/sample-docker-dind-sidecar/listener-dind-sidecar-no-resources.yaml
+++ b/container-registry/sample-docker-dind-sidecar/listener-dind-sidecar-no-resources.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: pipeline-debug

--- a/container-registry/sample-docker-dind-sidecar/listener-docker-in-docker.yaml
+++ b/container-registry/sample-docker-dind-sidecar/listener-docker-in-docker.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: pipeline-debug

--- a/container-registry/sample/listener-buildkit-no-resources.yaml
+++ b/container-registry/sample/listener-buildkit-no-resources.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: path-to-dockerfile

--- a/container-registry/sample/listener-container-registry.yaml
+++ b/container-registry/sample/listener-container-registry.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: image-url
       description: The image url in your container registry
     - name: path-to-dockerfile

--- a/git/sample-git-trigger/listener-sample-git-trigger.yaml
+++ b/git/sample-git-trigger/listener-sample-git-trigger.yaml
@@ -7,8 +7,6 @@ spec:
   params:
     - name: git-access-token
       description: the token to access the git repository for the clone operations
-    - name: apikey
-      description: the ibmcloud api key
       default: " "
     - name: repository
       description: The git repo

--- a/git/sample-set-commit-status/listener-commit-status.yaml
+++ b/git/sample-set-commit-status/listener-commit-status.yaml
@@ -5,8 +5,6 @@ metadata:
   name: set-commit-status
 spec:
   params:
-    - name: apikey
-      description: the ibmcloud api key
     - name: repository
       description: The git repo
     - name: branch

--- a/git/sample-skip-ci/listener-skip-ci.yaml
+++ b/git/sample-skip-ci/listener-skip-ci.yaml
@@ -39,6 +39,8 @@ spec:
             value: $(params.repository)
           - name: branch
             value: $(params.branch)
+          - name: apikey
+            value: $(params.apikey)
           - name: commit-message
             value: $(params.commit-message)
           - name: pipeline-debug
@@ -51,7 +53,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
-  name: github-commit
+  name: github-commit-trigger
 spec:
   params:
     - name: repository
@@ -66,10 +68,10 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: github-commit
+  name: github-commit-listener
 spec:
   triggers:
     - binding:
-        name: github-commit
+        name: github-commit-trigger
       template:
         name: skip-ci

--- a/git/sample-skip-ci/listener-skip-ci.yaml
+++ b/git/sample-skip-ci/listener-skip-ci.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: commit-message
       default: ""
     - name: pipeline-debug
@@ -39,8 +37,6 @@ spec:
             value: $(params.repository)
           - name: branch
             value: $(params.branch)
-          - name: apikey
-            value: $(params.apikey)
           - name: commit-message
             value: $(params.commit-message)
           - name: pipeline-debug

--- a/git/sample/listener-simple-clone.yaml
+++ b/git/sample/listener-simple-clone.yaml
@@ -9,8 +9,6 @@ spec:
       description: The git repo
     - name: branch
       description: the branch for the git repo
-    - name: apikey
-      description: the ibmcloud api key
     - name: git-access-token
       description: illustrate alternate way to provide/get git access token
       default: ""

--- a/kubernetes-service/sample/listener-kubernetes-service-no-resources.yaml
+++ b/kubernetes-service/sample/listener-kubernetes-service-no-resources.yaml
@@ -5,8 +5,6 @@ metadata:
   name: kubernetes-service-no-resources
 spec:
   params:
-    - name: apikey
-      description: the ibmcloud api key
     - name: cluster-name
       description: the name of the cluster to target
     - name: resource-group

--- a/kubernetes-service/sample/listener-kubernetes-service.yaml
+++ b/kubernetes-service/sample/listener-kubernetes-service.yaml
@@ -5,8 +5,6 @@ metadata:
   name: trigger-template-kubernetes-service
 spec:
   params:
-    - name: apikey
-      description: the ibmcloud api key
     - name: cluster-name
       description: the name of the cluster to target
     - name: resource-group

--- a/signing/dct/task-dct-enforcement-policy.yaml
+++ b/signing/dct/task-dct-enforcement-policy.yaml
@@ -18,9 +18,6 @@ spec:
     - name: helm-version
       description: specific helm version
       default: 2.16.6
-    - name: ibmcloud-api
-      description: the ibmcloud api
-      default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
       description: name of the secret containing the continuous delivery pipeline context secrets
       default: secure-properties

--- a/signing/dct/task-dct-init.yaml
+++ b/signing/dct/task-dct-init.yaml
@@ -23,9 +23,6 @@ spec:
       description: validation signer
     - name: build-signer
       description: build signer
-    - name: ibmcloud-api
-      description: the ibmcloud api
-      default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
       description: name of the secret containing the continuous delivery pipeline context secrets
       default: secure-properties

--- a/signing/dct/task-dct-sign.yaml
+++ b/signing/dct/task-dct-sign.yaml
@@ -19,9 +19,6 @@ spec:
       description: the resource group of the keyprotect instance
     - name: vault-name
       description: the key protect instance name
-    - name: ibmcloud-api
-      description: the ibmcloud api
-      default: https://cloud.ibm.com
     - name: continuous-delivery-context-secret
       description: name of the secret containing the continuous delivery pipeline context secrets
       default: secure-properties


### PR DESCRIPTION
- Adds tekton-lint as a Github action to be run on all commits. 
- Fix up tekton-lint errors, mostly by removing unused parameters.
- Lingering tekton-lint error: `'alpine/git` docker image used in `git/task-clone-repo.yaml` should be tagged with a specific version instead of using `latest`.
```
git/task-clone-repo.yaml:
warning (186,14,186,24): Invalid image: 'alpine/git' for step 'clone-repo' in Task 'git-clone-repo'. Specify the image tag instead of using ':latest'
```