### PR TITLE
removed user-name from pr run

### DIFF
--- a/cra/sample/pr-trigger.yaml
+++ b/cra/sample/pr-trigger.yaml
@@ -58,7 +58,7 @@ spec:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: pullrequest-$(params.pr-number)-from-$(params.pr-name)-user
+        name: pipelinerun-$(uid)
       spec:
         pipelineRef:
           name: pr-pipeline


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

There's an issue reported as below: 
<img width="873" alt="Screenshot 2020-11-18 at 7 55 12 PM" src="https://user-images.githubusercontent.com/8685412/99832529-ac0daf00-2b2e-11eb-9ba2-9349cdd1273e.png">

removing user-name from pr-name.