### PR TITLE
cra support for auth base images

### DIFF
--- a/cra/README.md
+++ b/cra/README.md
@@ -40,6 +40,17 @@ any add-on packages installed on top of base image(s).
 
 - **artifacts**: The output volume to check out and store task scripts & data between tasks
 
+#### Implicit / data from the pipeline
+
+**Base image pulls secrets (optional)**
+
+To provide pull credentials for the base image you use in your Dockerfile, for example for a UBI image from Red Hat registry, add these variables to your pipeline on he pipeline UI. The Task will look for them and if they are present, it will add an entry to the proper `config.json` for docker.
+
+- **baseimage-auth-user** The username to the registry (Type: `text`)
+- **baseimage-auth-password** The password to the registry (Type: `SECRET`)
+- **baseimage-auth-host** The registry host name (Type: `text`)
+- **baseimage-auth-email** An email address to the registry account (Type: `text`)
+
 ### Results
 
 - **status**: Status of cra discovery task, possible value are - success|failure

--- a/cra/task-discovery.yaml
+++ b/cra/task-discovery.yaml
@@ -186,4 +186,4 @@ spec:
     - name: secure-properties
       secret:
         secretName: $(params.continuous-delivery-context-secret)
-        
+

--- a/cra/task-discovery.yaml
+++ b/cra/task-discovery.yaml
@@ -25,6 +25,9 @@ spec:
     - name: ibmcloud-apikey-secret-key
       description: field in the secret that contains the api key used to login to ibmcloud
       default: apikey
+    - name: continuous-delivery-context-environment
+      description: Name of the configmap containing the continuous delivery pipeline context environment properties
+      default: environment-properties
 
   results:
     - name: status
@@ -45,6 +48,10 @@ spec:
               name: $(params.continuous-delivery-context-secret)
               key: $(params.ibmcloud-apikey-secret-key)
               optional: true
+        # The location of the client configuration files.
+        - name: DOCKER_CONFIG
+          value: /artifacts      
+
       imagePullPolicy: Always
       workingDir: "/artifacts"
       command: ["/bin/sh", "-c"]
@@ -106,6 +113,24 @@ spec:
             exit 1
           fi
 
+          # create a dry-run k8s secret of type docker-registry to obtain 
+          # the pull secrets for the base image used in the dockerfile
+          # this is optional, but sometimes useful, for example when using
+          # UBI images from RedHat
+           
+          if [ -f "/properties/baseimage-auth-user" ] \
+            && [ -f "/secrets/baseimage-auth-password" ] \
+            && [ -f "/properties/baseimage-auth-host" ]; then
+            echo "Adding pull secrets to access base image registry $(cat /properties/baseimage-auth-host)"
+            kubectl create secret --dry-run=client --output=json \
+              docker-registry registry-dockerconfig-secret \
+              --docker-username="$(cat /properties/baseimage-auth-user)" \
+              --docker-password="$(cat /secrets/baseimage-auth-password)" \
+              --docker-server="$(cat /properties/baseimage-auth-host)" \
+              --docker-email="$(cat /properties/baseimage-auth-email)" | \
+              jq -r '.data[".dockerconfigjson"]' | base64 -d > config.json
+          fi
+
           /usr/local/bin/discovery \
             -giturl "$(params.repository)" \
             -gitbranch "$(params.revision)" \
@@ -119,6 +144,10 @@ spec:
           name: config-volume
         - mountPath: /var/run/
           name: docker-socket
+        - mountPath: /properties
+          name: environment-properties
+        - mountPath: /secrets
+          name: secure-properties    
 
   sidecars:
     - image: docker:19.03-dind
@@ -151,3 +180,10 @@ spec:
         name: toolchain
     - name: docker-socket
       emptyDir: {}
+    - name: environment-properties
+      configMap:
+        name: $(params.continuous-delivery-context-environment)
+    - name: secure-properties
+      secret:
+        secretName: $(params.continuous-delivery-context-secret)
+        


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

In CRA: we are adding support for scanning base images from private authenticated registries.

User need to specify following properties as ENV to the pipeline to enable this scanning.

- **baseimage-auth-user** The username to the registry (Type: `text`)
- **baseimage-auth-password** The password to the registry (Type: `SECRET`)
- **baseimage-auth-host** The registry host name (Type: `text`)
- **baseimage-auth-email** An email address to the registry account (Type: `text`)

These are optional parameters. So in absence of these, pipeline should still work, but would fail to scan images from auth registries