### PR TITLE
Use ibmcloud target -r instead of cr region-set to use region affinity as a fallback

### DIFF
--- a/container-registry/configmap-check-registry.yaml
+++ b/container-registry/configmap-check-registry.yaml
@@ -72,7 +72,15 @@ data:
     fi
 
     # Log container registry to the appropriate region
-    ibmcloud cr region-set $REGISTRY_REGION
+    if ibmcloud cr region-set $REGISTRY_REGION > /dev/null 2>&1; then
+      echo "ibmcloud container registry region set to $REGISTRY_REGION"
+    else
+      # the registry region specified is not supported - fallback on
+      # using ibmcloud target -r command to rely on region affinity
+      # for container registry region - for instance us-east does not have
+      # a container-registry service, it is defered to us-south
+      ibmcloud target -r $REGISTRY_REGION
+    fi
     ibmcloud cr info
 
     # Check available quota on CR

--- a/container-registry/task-check-va-scan.yaml
+++ b/container-registry/task-check-va-scan.yaml
@@ -149,7 +149,15 @@ spec:
           fi
 
           # Log container registry to the appropriate region
-          ibmcloud cr region-set $REGISTRY_REGION
+          if ibmcloud cr region-set $REGISTRY_REGION > /dev/null 2>&1; then
+            echo "ibmcloud container registry region set to $REGISTRY_REGION"
+          else
+            # the registry region specified is not supported - fallback on
+            # using ibmcloud target -r command to rely on region affinity
+            # for container registry region - for instance us-east does not have
+            # a container-registry service, it is defered to us-south
+            ibmcloud target -r $REGISTRY_REGION
+          fi
           ibmcloud cr info
 
           # Because of https://github.com/tektoncd/pipeline/issues/216 the image digest for input is probably empty


### PR DESCRIPTION
Use ibmcloud target -r instead of cr region-set to use region affinity as a fallback
https://github.ibm.com/org-ids/roadmap/issues/15192