### PR TITLE
upddated param names for consistency

### DIFF
--- a/cra/README.md
+++ b/cra/README.md
@@ -48,10 +48,10 @@ any add-on packages installed on top of base image(s).
 
 To provide pull credentials for the base image you use in your Dockerfile, for example for a UBI image from Red Hat registry, add these variables to your pipeline on he pipeline UI. The Task will look for them and if they are present, it will add an entry to the proper `config.json` for docker.
 
-- **baseimage-auth-user** The username to the registry (Type: `text`)
-- **baseimage-auth-password** The password to the registry (Type: `SECRET`)
-- **baseimage-auth-host** The registry host name (Type: `text`)
-- **baseimage-auth-email** An email address to the registry account (Type: `text`)
+- **build-baseimage-auth-user** The username to the registry (Type: `text`)
+- **build-baseimage-auth-password** The password to the registry (Type: `SECRET`)
+- **build-baseimage-auth-host** The registry host name (Type: `text`)
+- **build-baseimage-auth-email** An email address to the registry account (Type: `text`)
 
 ### Results
 

--- a/cra/task-discovery.yaml
+++ b/cra/task-discovery.yaml
@@ -118,16 +118,16 @@ spec:
           # this is optional, but sometimes useful, for example when using
           # UBI images from RedHat
            
-          if [ -f "/properties/baseimage-auth-user" ] \
-            && [ -f "/secrets/baseimage-auth-password" ] \
-            && [ -f "/properties/baseimage-auth-host" ]; then
-            echo "Adding pull secrets to access base image registry $(cat /properties/baseimage-auth-host)"
+          if [ -f "/properties/build-baseimage-auth-user" ] \
+            && [ -f "/secrets/build-baseimage-auth-password" ] \
+            && [ -f "/properties/build-baseimage-auth-host" ]; then
+            echo "Adding pull secrets to access base image registry $(cat /properties/build-baseimage-auth-host)"
             kubectl create secret --dry-run=client --output=json \
               docker-registry registry-dockerconfig-secret \
-              --docker-username="$(cat /properties/baseimage-auth-user)" \
-              --docker-password="$(cat /secrets/baseimage-auth-password)" \
-              --docker-server="$(cat /properties/baseimage-auth-host)" \
-              --docker-email="$(cat /properties/baseimage-auth-email)" | \
+              --docker-username="$(cat /properties/build-baseimage-auth-user)" \
+              --docker-password="$(cat /secrets/build-baseimage-auth-password)" \
+              --docker-server="$(cat /properties/build-baseimage-auth-host)" \
+              --docker-email="$(cat /properties/build-baseimage-auth-email)" | \
               jq -r '.data[".dockerconfigjson"]' | base64 -d > config.json
           fi
 


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <nadgowda@us.ibm.com>

Updated following parameter names (please note: `build-` is appended) to param names. This change was made for param consistency for authenticating private registry. 

```
- **build-baseimage-auth-user** The username to the registry (Type: `text`)
- **build-baseimage-auth-password** The password to the registry (Type: `SECRET`)
- **build-baseimage-auth-host** The registry host name (Type: `text`)
- **build-baseimage-auth-email** An email address to the registry account (Type: `text`)
```