### PR TITLE
update buildkit version

### DIFF
--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -47,7 +47,7 @@ spec:
       default: ""
     - name: buildkit-image
       description: The name of the BuildKit image
-      default: "moby/buildkit:v0.7.2"
+      default: "moby/buildkit:v0.8.1"
     - name: additional-tags
       description: comma-separated list of additional-tags
       # can not be defined as an array because of variable substition error for array


### PR DESCRIPTION
v0.7.2 causes this issue when building Watson starter kits:
```
error: failed to solve: rpc error: code = Unknown desc = invalid incomplete links
```

This issue is fixed in v.0.8.0: https://github.com/moby/buildkit/issues/1509