### PR TITLE
Revert "Update Discovery image, add comm-editor checks"

### DIFF
--- a/cra/task-bom.yaml
+++ b/cra/task-bom.yaml
@@ -286,27 +286,6 @@ spec:
           #!/bin/sh
           source /steps/next-step-env.properties
 
-          case "$(params.repository)" in
-            *git.cloud.ibm.com*)
-            if [ "$(params.scm-type)" != "gitlab" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be gitlab"
-              exit 1
-            fi
-            ;;
-          *ibm.com*)
-            if [ "$(params.scm-type)" != "github-ent" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github-ent"
-              exit 1
-            fi
-            ;;
-          *)
-            if [ "$(params.scm-type)" != "github" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github"
-              exit 1
-            fi
-            ;;
-          esac
-
           /usr/local/bin/comm-editor \
             -repo-url "$(params.repository)" \
             -pr-url "$(params.pr-url)" \
@@ -314,12 +293,6 @@ spec:
             -comment-fp "$COMMENT_FP" \
             -project-id "$(params.project-id)" \
             -scm-type "$(params.scm-type)"
-
-          COMM_RESULT=$?
-          if [ "$COMM_RESULT" != "0" ]; then
-            echo "Error posting comment to pull request"
-            exit 1
-          fi
 
       volumeMounts:
         - mountPath: /steps

--- a/cra/task-cis-check.yaml
+++ b/cra/task-cis-check.yaml
@@ -60,7 +60,7 @@ spec:
         value: $(params.pipeline-debug)
   steps:
     - name: cis
-      image: icr.io/continuous-delivery/cra-cis:release.1567
+      image: icr.io/continuous-delivery/cra-cis:release.1498
       env:
         - name: REPOSITORY
           value: $(params.repository)
@@ -272,27 +272,6 @@ spec:
           #!/bin/sh
           source /steps/next-step-env.properties
 
-          case "$(params.repository)" in
-            *git.cloud.ibm.com*)
-            if [ "$(params.scm-type)" != "gitlab" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be gitlab"
-              exit 1
-            fi
-            ;;
-          *ibm.com*)
-            if [ "$(params.scm-type)" != "github-ent" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github-ent"
-              exit 1
-            fi
-            ;;
-          *)
-            if [ "$(params.scm-type)" != "github" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github"
-              exit 1
-            fi
-            ;;
-          esac
-
           /usr/local/bin/comm-editor \
             -repo-url "$(params.repository)" \
             -pr-url "$(params.pr-url)" \
@@ -300,12 +279,6 @@ spec:
             -comment-fp "$COMMENT_FP" \
             -project-id "$(params.project-id)" \
             -scm-type "$(params.scm-type)"
-
-          COMM_RESULT=$?
-          if [ "$COMM_RESULT" != "0" ]; then
-            echo "Error posting comment to pull request"
-            exit 1
-          fi
 
       volumeMounts:
         - mountPath: /steps

--- a/cra/task-comm-editor.yaml
+++ b/cra/task-comm-editor.yaml
@@ -28,27 +28,6 @@ spec:
           #!/bin/sh
           source /steps/next-step-env.properties
 
-          case "$(params.repository)" in
-            *git.cloud.ibm.com*)
-            if [ "$(params.scm-type)" != "gitlab" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be gitlab"
-              exit 1
-            fi
-            ;;
-          *ibm.com*)
-            if [ "$(params.scm-type)" != "github-ent" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github-ent"
-              exit 1
-            fi
-            ;;
-          *)
-            if [ "$(params.scm-type)" != "github" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github"
-              exit 1
-            fi
-            ;;
-          esac
-
           /usr/local/bin/comm-editor \
             -repo-url "$(params.repository)" \
             -pr-url "$(params.pr-url)" \
@@ -57,12 +36,6 @@ spec:
             -comment-fp "$(params.comment-fp)" \
             -project-id "$(params.project-id)" \
             -scm-type "$(params.scm-type)"
-
-          COMM_RESULT=$?
-          if [ "$COMM_RESULT" != "0" ]; then
-            echo "Error posting comment to pull request"
-            exit 1
-          fi
 
   workspaces:
     - name: artifacts

--- a/cra/task-discovery.yaml
+++ b/cra/task-discovery.yaml
@@ -40,7 +40,7 @@ spec:
 
   steps:
     - name: discovery
-      image: icr.io/continuous-delivery/cra-discovery:release.1571
+      image: icr.io/continuous-delivery/cra-discovery:release.1525
       env:
         - name: API_KEY
           valueFrom:

--- a/cra/task-terraform-compliance.yaml
+++ b/cra/task-terraform-compliance.yaml
@@ -292,27 +292,6 @@ spec:
           #!/bin/sh
           source /steps/next-step-env.properties
 
-          case "$(params.repository)" in
-            *git.cloud.ibm.com*)
-            if [ "$(params.scm-type)" != "gitlab" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be gitlab"
-              exit 1
-            fi
-            ;;
-          *ibm.com*)
-            if [ "$(params.scm-type)" != "github-ent" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github-ent"
-              exit 1
-            fi
-            ;;
-          *)
-            if [ "$(params.scm-type)" != "github" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github"
-              exit 1
-            fi
-            ;;
-          esac
-
           /usr/local/bin/comm-editor \
             -repo-url "$(params.repository)" \
             -pr-url "$(params.pr-url)" \
@@ -320,12 +299,6 @@ spec:
             -comment-fp "$COMMENT_FP" \
             -project-id "$(params.project-id)" \
             -scm-type "$(params.scm-type)"
-
-          COMM_RESULT=$?
-          if [ "$COMM_RESULT" != "0" ]; then
-            echo "Error posting comment to pull request"
-            exit 1
-          fi
 
       volumeMounts:
         - mountPath: /steps

--- a/cra/task-vulnerability-remediation.yaml
+++ b/cra/task-vulnerability-remediation.yaml
@@ -278,27 +278,6 @@ spec:
           #!/bin/sh
           source /steps/next-step-env.properties
 
-          case "$(params.repository)" in
-            *git.cloud.ibm.com*)
-            if [ "$(params.scm-type)" != "gitlab" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be gitlab"
-              exit 1
-            fi
-            ;;
-          *ibm.com*)
-            if [ "$(params.scm-type)" != "github-ent" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github-ent"
-              exit 1
-            fi
-            ;;
-          *)
-            if [ "$(params.scm-type)" != "github" ]; then
-              echo "Error: Trigger type '$(params.scm-type)' expected to be github"
-              exit 1
-            fi
-            ;;
-          esac
-
           /usr/local/bin/comm-editor \
             -repo-url "$(params.repository)" \
             -pr-url "$(params.pr-url)" \
@@ -306,12 +285,6 @@ spec:
             -comment-fp "$COMMENT_FP" \
             -project-id "$(params.project-id)" \
             -scm-type "$(params.scm-type)"
-
-          COMM_RESULT=$?
-          if [ "$COMM_RESULT" != "0" ]; then
-            echo "Error posting comment to pull request"
-            exit 1
-          fi
 
       volumeMounts:
         - mountPath: /steps


### PR DESCRIPTION
Need to revert this change as it's breaking existing CI pipelines manual runs. These changes now expect a `scmType` which previously was not required