### PR TITLE
Latest Release Image for Discovery

### DIFF
--- a/cra/task-discovery.yaml
+++ b/cra/task-discovery.yaml
@@ -48,7 +48,7 @@ spec:
 
   steps:
     - name: discovery
-      image: icr.io/continuous-delivery/cra-discovery:release.1651
+      image: icr.io/continuous-delivery/cra-discovery:release.1698
       env:
         - name: API_KEY
           valueFrom:


### PR DESCRIPTION
Work Items:
- Add warnings for missing app package file 
- Warnings for attempts when building package-lock.json 
- Default Python to 3.9.2 for Pip Dependency Scanning.
