### PR TITLE
Update vulnerability to image cra-vulnerability:release.1768

### DIFF
--- a/cra/task-vulnerability-remediation.yaml
+++ b/cra/task-vulnerability-remediation.yaml
@@ -61,7 +61,7 @@ spec:
         value: $(params.pipeline-debug)
   steps:
     - name: remediation
-      image: icr.io/continuous-delivery/cra-vulnerability:main.1764
+      image: icr.io/continuous-delivery/cra-vulnerability:release.1768
       env:
         - name: REPOSITORY
           value: $(params.repository)

--- a/cra/task-vulnerability-remediation.yaml
+++ b/cra/task-vulnerability-remediation.yaml
@@ -61,7 +61,7 @@ spec:
         value: $(params.pipeline-debug)
   steps:
     - name: remediation
-      image: icr.io/continuous-delivery/cra-vulnerability:release.1745
+      image: icr.io/continuous-delivery/cra-vulnerability:main.1764
       env:
         - name: REPOSITORY
           value: $(params.repository)


### PR DESCRIPTION
Includes feature to allow Snyk id for CVE omission. Handles vulnerabilities with no CVE id.

@jauninb 