### PR TITLE
git/task-clone-repo, others, no need for ibmcloud region

### DIFF
--- a/container-registry/configmap-check-registry.yaml
+++ b/container-registry/configmap-check-registry.yaml
@@ -66,11 +66,10 @@ data:
     ##########################################################################
 
     TOOLCHAIN_ID=$(jq -r '.toolchain_guid' /cd-config/toolchain.json)
-    TOOLCHAIN_REGION=$(jq -r '.region_id' /cd-config/toolchain.json | awk -F: '{print $3}')
 
     # ibmcloud login
     ibmcloud config --check-version false
-    ibmcloud login -a $IBMCLOUD_API -r $TOOLCHAIN_REGION --apikey $API_KEY
+    ibmcloud login -a $IBMCLOUD_API --no-region --apikey $API_KEY
     if [ "$IBMCLOUD_RESOURCE_GROUP" ]; then
       ibmcloud target -g "$IBMCLOUD_RESOURCE_GROUP"
     fi

--- a/container-registry/task-check-va-scan.yaml
+++ b/container-registry/task-check-va-scan.yaml
@@ -86,7 +86,6 @@ spec:
           fi
 
           TOOLCHAIN_ID=$(jq -r '.toolchain_guid' /cd-config/toolchain.json)
-          TOOLCHAIN_REGION=$(jq -r '.region_id' /cd-config/toolchain.json | awk -F: '{print $3}')
           ##########################################################################
           # Setting HOME explicitly to have ibmcloud plugins available
           # doing the export rather than env definition is a workaround
@@ -146,7 +145,7 @@ spec:
 
           # ibmcloud login
           ibmcloud config --check-version false
-          ibmcloud login -a $(params.ibmcloud-api) -r $TOOLCHAIN_REGION --apikey $API_KEY
+          ibmcloud login -a $(params.ibmcloud-api) --no-region --apikey $API_KEY
           if [ "$(params.resource-group)" ]; then
             ibmcloud target -g "$(params.resource-group)"
           fi

--- a/git/task-clone-repo.yaml
+++ b/git/task-clone-repo.yaml
@@ -109,7 +109,6 @@ spec:
         fi
 
         TOOLCHAIN_ID=$(jq -r '.toolchain_guid' /cd-config/toolchain.json)
-        TOOLCHAIN_REGION=$(jq -r '.region_id' /cd-config/toolchain.json | awk -F: '{print $3}')
         ##########################################################################
         # Setting HOME explicitly to have ibmcloud plugins available
         # doing the export rather than env definition is a workaround
@@ -147,7 +146,7 @@ spec:
         if [ -z "$GIT_TOKEN" ]; then
           echo "Fetching token for $REPOSITORY"
           ibmcloud config --check-version false
-          ibmcloud login -a $(params.ibmcloud-api) -r $TOOLCHAIN_REGION --apikey $API_KEY
+          ibmcloud login -a $(params.ibmcloud-api) --no-region --apikey $API_KEY
           if [ "$(params.resource-group)" ]; then
             ibmcloud target -g "$(params.resource-group)"
           fi

--- a/toolchain/task-publish-deployable-mapping.yaml
+++ b/toolchain/task-publish-deployable-mapping.yaml
@@ -120,7 +120,7 @@ spec:
         TOOLCHAIN_REGION=$(jq -r '.region_id' /cd-config/toolchain.json | awk -F: '{print $3}')
 
         ibmcloud config --check-version false
-        ibmcloud login -a $(params.ibmcloud-api) -r $TOOLCHAIN_REGION --apikey $IBM_CLOUD_API_KEY
+        ibmcloud login -a $(params.ibmcloud-api) --no-region --apikey $IBM_CLOUD_API_KEY
         TOKEN=$(ibmcloud iam oauth-tokens --output JSON | jq -r '.iam_token')
 
         if [ $(echo "$REGION_ID" | grep -c ':' -) -ne 1 ]; then


### PR DESCRIPTION
and the region parameter was causing problems
in an internal staging/test region.
The ibmcloud login is only needed for the
ibmcloud iam oauth-tokens,
so no need for region or resource group to be configured.