### PR TITLE
Handle Git Tag refs

### DIFF
--- a/git/task-clone-repo.yaml
+++ b/git/task-clone-repo.yaml
@@ -228,7 +228,9 @@ spec:
         source /steps/next-step-env.properties
 
         # If $BRANCH is a full git ref then only keep the name part
+        # this is using sh so do this in two steps
         BRANCH=$(echo ${BRANCH#"refs/heads/"})
+        BRANCH=$(echo ${BRANCH#"refs/tags/"})
 
         echo "Cloning $REPOSITORY"
         # Add the proper creds to the git repository


### PR DESCRIPTION
If you create a tag in github, then the ref is refs/tags/xxxx
Only checking for heads means this clone would fail

Note that shell is sh, for bash I would have done

```
# If BASH is ever used it could be this
re="refs/(heads|tags)/(.*)"
if [[ $BRANCH =~ $re ]]; then
  BRANCH=${BASH_REMATCH[2]}
fi
```
Raised in response to issue #250 
Signed-off-by: Matthew B White <whitemat@uk.ibm.com>