### PR TITLE
support new container registry region ca-tor

### DIFF
--- a/container-registry/configmap-check-registry.yaml
+++ b/container-registry/configmap-check-registry.yaml
@@ -50,6 +50,8 @@ data:
         REGISTRY_REGION="us-south"
       elif [ "$REGISTRY_REGION" == "fr2" ]; then
         REGISTRY_REGION="eu-fr2"
+      elif [ "$REGISTRY_REGION" == "ca" ]; then
+        REGISTRY_REGION="ca-tor"
       else
         echo "No IBM Cloud Container Registry region found for the registry url $REGISTRY_URL"
         exit 1

--- a/container-registry/task-check-va-scan.yaml
+++ b/container-registry/task-check-va-scan.yaml
@@ -137,6 +137,8 @@ spec:
               REGISTRY_REGION="us-south"
             elif [ "$REGISTRY_REGION" == "fr2" ]; then
               REGISTRY_REGION="eu-fr2"
+            elif [ "$REGISTRY_REGION" == "ca" ]; then
+              REGISTRY_REGION="ca-tor"
             else
               echo "No IBM Cloud Container Registry region found for the registry url $INPUT_REGISTRY_URL"
               exit 1


### PR DESCRIPTION
Support new container registry region: ca-tor; Toronto, Canada.
It's in the command line list of regions:

$ ibmcloud cr region-set
Choose a region
1. ap-north ('jp.icr.io')
2. ap-south ('au.icr.io')
3. ca-tor ('ca.icr.io')
4. eu-central ('de.icr.io')
5. global ('icr.io')
6. jp-osa ('jp2.icr.io')
7. uk-south ('uk.icr.io')
8. us-south ('us.icr.io')
Enter a number ()> ^C
$