### PR TITLE
Fix bom evidence file name

### DIFF
--- a/cra/task-bom.yaml
+++ b/cra/task-bom.yaml
@@ -165,7 +165,7 @@ spec:
             -target_commitid "$(params.target-commit-id)" \
             -target_branch "$(params.target-branch)" \
             -results_status "$(results.status.path)" \
-            -results_evidence "./gitsecure-cis-results.json" \
+            -results_evidence "./gitsecure-bom-results.json" \
             -toolchainid "${TOOLCHAIN_ID}" \
             -comment_md "./gitsecure-bom-comment.md"
 


### PR DESCRIPTION
The evidence file name for bom was tagged incorrectly. It had 2 side-effects:
1. tasks that reads the evidence would get the report for CIS task
2. if this task finishes after CIS, then it would override CIS task results