### PR TITLE
fix: CLI bug

### DIFF
--- a/container-registry/task-execute-in-dind.yaml
+++ b/container-registry/task-execute-in-dind.yaml
@@ -156,10 +156,6 @@ spec:
             fi
             # export the expected environment variables now that the container registry is logged in
             export REGISTRY_URL=$(ibmcloud cr info | grep -m1 -i '^Container Registry' | awk '{print $3;}')
-            #restore previous behaviour for us-east region -> map to us-south for icr
-            if [[ "${REGISTRY_URL}" == "icr.io" && "${REGISTRY_REGION}" == "us-east" ]]; then
-              REGISTRY_URL="us.icr.io"
-            fi
             export IMAGE_URL="${REGISTRY_URL}/${REGISTRY_NAMESPACE}/${IMAGE_NAME}"
           fi
 


### PR DESCRIPTION
When targeting 'us-east' in the CLI, it looks at the global registry `icr.io`. So, changing the REGISTRY_URL to point to the 'us-south' registry is incorrect.