### PR TITLE
Add option to disable caching in BuildKit

### DIFF
--- a/container-registry/sample/listener-buildkit-no-resources.yaml
+++ b/container-registry/sample/listener-buildkit-no-resources.yaml
@@ -19,6 +19,8 @@ spec:
       default: "0"
     - name: properties-file
       default: ""
+    - name: disable-caching
+      default: "0"
   resourcetemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -53,6 +55,8 @@ spec:
             value: $(params.pipeline-debug)
           - name: properties-file
             value: $(params.properties-file)
+          - name: disable-caching
+            value: $(params.disable-caching)
         workspaces:
           - name: pipeline-ws
             persistentVolumeClaim:

--- a/container-registry/sample/pipeline-buildkit-no-resources.yaml
+++ b/container-registry/sample/pipeline-buildkit-no-resources.yaml
@@ -19,6 +19,8 @@ spec:
       default: "0"
     - name: properties-file
       default: ""
+    - name: disable-caching
+      default: "0"
   workspaces:
     - name: pipeline-ws
   tasks:
@@ -68,6 +70,8 @@ spec:
           value: $(params.properties-file)
         - name: pipeline-debug
           value: $(params.pipeline-debug)
+        - name: disable-caching
+          value: $(params.disable-caching)
       workspaces:
         - name: source
           workspace: pipeline-ws

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -219,6 +219,8 @@ spec:
               fieldPath: metadata.annotations['devops.cloud.ibm.com/triggered-by']
         - name: WORKSPACE_PATH
           value: $(workspaces.source.path)
+        - name: DISABLE_CACHING
+          value: $(params.disable-caching)
       securityContext:
         privileged: true
       command: ["/bin/sh", "-c"]
@@ -274,8 +276,12 @@ spec:
             BUILD_ARGS="${BUILD_ARGS} --opt build-arg:$buildArg "
           done
 
+          if [ $DISABLE_CACHING == 1 ]; then
+            DISABLE_CACHING="--no-cache"
+          fi
+
           buildctl --addr tcp://0.0.0.0:1234 build \
-            --no-cache \
+            ${DISABLE_CACHING} \
             --progress=plain \
             --frontend=dockerfile.v0 \
             --opt filename=$(params.dockerfile) \

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -280,11 +280,11 @@ spec:
           done
 
           if [ $DISABLE_CACHING == 1 ]; then
-            DISABLE_CACHING="--no-cache"
+            NO_CACHE="--no-cache"
           fi
 
           buildctl --addr tcp://0.0.0.0:1234 build \
-            ${DISABLE_CACHING} \
+            ${NO_CACHE} \
             --progress=plain \
             --frontend=dockerfile.v0 \
             --opt filename=$(params.dockerfile) \

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -275,6 +275,7 @@ spec:
           done
 
           buildctl --addr tcp://0.0.0.0:1234 build \
+            --no-cache \
             --progress=plain \
             --frontend=dockerfile.v0 \
             --opt filename=$(params.dockerfile) \

--- a/container-registry/task-containerize.yaml
+++ b/container-registry/task-containerize.yaml
@@ -73,6 +73,9 @@ spec:
     - name: pipeline-debug
       description: Pipeline debug mode. Value can be 0 or 1. Default to 0
       default: "0"
+    - name: disable-caching
+      description: Disable caching layers when building images. Value can be 0 or 1. Default to 0
+      default: "0"
   results:
     - name: image-repository
       description: the repository for the built image


### PR DESCRIPTION
At the moment when BuildKit (`buildctl`) builds the image it is using the default caching options. This means that steps get skipped if they are unchanged which can be useful for speeding up builds, but also means that steps such as `yum update` also don't take place. This means that the images can get flagged up for vulnerabilities by the VA scanner as the build does not pull in the latest system packages on top of the base image.

Matching our other build pipelines, we'd like to use the `--no-cache` option that's available in BuildKit (and also in Docker), and make that an optional parameter on the BuildKit pipeline.

Validated this works on our IBM Cloud toolchain pipeline.